### PR TITLE
Replace standard paragraphs with enhanced elements

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -155,6 +155,14 @@ export function init(dom, context, config, mediator) {
         || navigator.maxTouchPoints;       // works on IE10/11 and Surface
   };
 
+  function replaceElement(list, text, element) {
+    for (var i = 0; i < list.length; i++) {
+      if (list[i].textContent.toLowerCase()==text) {
+        console.log(text);
+        list[i].parentNode.replaceChild(element, list[i]);
+      }
+    }
+  }
 
   function optional_add_quotes_to_standfirst(quotes) {
     var standfirst = document.querySelector('.content__standfirst--explore');

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -110,16 +110,17 @@ export function init(dom, context, config, mediator) {
     newsletterItem.innerHTML = comingSoonText + "<form method='post' novalidate action='https://guardiannewsampampmedia.formstack.com/forms/index.php' class='fsForm fsSingleColumn fsMaxCol1' id='fsForm2490271'><input type='hidden' name='form' value='2490271' /><input type='hidden' name='viewkey' value='tOfqZ3Kxj2' /><input type='hidden' name='password' value='' /><input type='hidden' name='hidden_fields' id='hidden_fields2490271' value='' /><input type='hidden' name='fspublicsession' id='session_id2490271' value='' /><input type='hidden' name='incomplete' id='incomplete2490271' value='' /><input type='hidden' name='incomplete_email' id='incomplete_email2490271' value='' /><input type='hidden' name='incomplete_password' id='incomplete_password2490271' /><input type='hidden' name='referrer' id='referrer2490271' value='' /><input type='hidden' name='referrer_type' id='referrer_type2490271' value='link' /><input type='hidden' name='_submit' value='1' /><input type='hidden' name='style_version' value='3' /><input type='hidden' id='fsLatitude' name='latitude' value='' /><input type='hidden' id='fsLongitude' name='longitude' value='' /><input type='hidden' id='viewparam' name='viewparam' value='551498' /><input type='hidden' id='analytics' name='analytics' value='' /><input type='hidden' id='fsSaveResumePassword2490271' value='1' /><label id='label46135110' class='fsLabel fsRequiredLabel' for='field46135110'>Sign up for an email alert when new articles are published</label><input type='email' placeholder='Your email' id='field46135110' name='field46135110' required='required' value='' class='fsField fsFormatEmail fsRequired' aria-required='true' /><div class='marketing'><input type='checkbox' id='field46329861_1' name='field46329861[]' value='I'd also like to receive the latest updates and offers from the Guardian' checked='checked' class='fsField vertical' data-link-name='middletown : newsletter checkbox'><label class='fsOptionLabel vertical' for='field46329861_1'  data-link-name='middletown : newsletter checkbox text'>I'd also like to receive the latest updates and offers from the Guardian</label><p>By proceeding, you agree to the Guardian's <a href='https://www.theguardian.com/help/terms-of-service'>Terms of Service</a> &amp; <a href='https://www.theguardian.com/info/privacy'>Privacy Policy</a>.</p></div><input id='fsSubmitButton2490271' class='fsSubmitButton' type='submit' value='Subscribe' data-link-name='middletown : newsletter sign up in-article' /></form>";
 
     if (!isCalloutPage()) {
-      textBody.insertBefore(atomItem, textBody.childNodes[10]);
-      textBody.insertBefore(newsletterItem, textBody.childNodes[textBody.childNodes.length]);
       headlineContainer.appendChild(seriesPageItem);
       textBody.insertBefore(overlayItem, textBody.childNodes[0]);
-      textBody.insertBefore(linkItem, textBody.childNodes[20]);
-
-      // document.querySelector('.content__standfirst--explore').classList.add('quote');
     }
 
     optional_add_quotes_to_standfirst(["'", '"', '’', '‘', '“', '”']);
+
+    var textBodyP = textBody.querySelectorAll('p');
+    replaceElement(textBodyP, "{{atom}}", atomItem);
+    replaceElement(textBodyP, "{{callout link}}", linkItem);
+    replaceElement(textBodyP, "{{newsletter signup}}", newsletterItem);
+
 
     [].forEach.call(document.querySelectorAll('.content__series-label__link'), function(link) {
       link.setAttribute('href', 'https://www.theguardian.com/membership/ng-interactive/2016/oct/11/view-middletown-gary-younge-us-presidential-election');


### PR DESCRIPTION
This adds a function to replace paragraphs with special text (like handlebars-style {{atom}}), with our enhanced elements.

We need to add the text nodes and test it before pushing tho. Also, something to look out for is the paragraphs need to have only the special text, i.e {{atom}} and no spaces or anything else…
